### PR TITLE
Add build scripts and feedback listing functionality

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+echo "🏗️  Building Coaching Application..."
+echo "===================================="
+
+echo "📁 Building Backend..."
+cd backend
+./build.sh
+if [ $? -ne 0 ]; then
+    echo "❌ Backend build failed!"
+    exit 1
+fi
+cd ..
+
+echo "📁 Building Frontend..."
+cd frontend
+echo "Installing dependencies..."
+bun install
+echo "Building frontend..."
+bun run build
+if [ $? -ne 0 ]; then
+    echo "❌ Frontend build failed!"
+    exit 1
+fi
+cd ..
+
+echo "===================================="
+echo "✅ All builds completed successfully!"
+echo "🚀 You can now run: ./start.sh"
+echo "===================================="

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -268,6 +268,95 @@ body {
   line-height: 1.5;
 }
 
+.filters {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.filters .form-group {
+  min-width: 200px;
+}
+
+.feedback-stats {
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.feedback-card {
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.feedback-card .feedback-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.feedback-type {
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.feedback-type.team {
+  background-color: #dbeafe;
+  color: #1e40af;
+}
+
+.feedback-type.member {
+  background-color: #d1fae5;
+  color: #047857;
+}
+
+.feedback-target {
+  font-weight: 600;
+  color: #374151;
+}
+
+.feedback-date {
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.feedback-content {
+  background: white;
+  padding: 0.75rem;
+  border-radius: 0.375rem;
+  border: 1px solid #e5e7eb;
+  color: #374151;
+  line-height: 1.6;
+}
+
+.no-data {
+  text-align: center;
+  color: #6b7280;
+  font-style: italic;
+  padding: 2rem;
+  background: #f9fafb;
+  border-radius: 0.5rem;
+}
+
+.error {
+  color: #dc2626;
+  background-color: #fef2f2;
+  padding: 1rem;
+  border-radius: 0.375rem;
+  border: 1px solid #fecaca;
+  margin-bottom: 1rem;
+}
+
 @media (max-width: 768px) {
   .navbar {
     padding: 1rem;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,9 +4,10 @@ import AddTeamMember from './pages/AddTeamMember';
 import CreateTeam from './pages/CreateTeam';
 import AssignToTeam from './pages/AssignToTeam';
 import GiveFeedback from './pages/GiveFeedback';
+import ListFeedback from './pages/ListFeedback';
 import './App.css';
 
-type Page = 'add-member' | 'create-team' | 'assign-team' | 'give-feedback';
+type Page = 'add-member' | 'create-team' | 'assign-team' | 'give-feedback' | 'list-feedback';
 
 function App() {
   const [currentPage, setCurrentPage] = useState<Page>('add-member');
@@ -21,6 +22,8 @@ function App() {
         return <AssignToTeam />;
       case 'give-feedback':
         return <GiveFeedback />;
+      case 'list-feedback':
+        return <ListFeedback />;
       default:
         return <AddTeamMember />;
     }
@@ -55,6 +58,12 @@ function App() {
               onClick={() => setCurrentPage('give-feedback')}
             >
               Give Feedback
+            </button>
+            <button
+              className={`nav-button ${currentPage === 'list-feedback' ? 'active' : ''}`}
+              onClick={() => setCurrentPage('list-feedback')}
+            >
+              List Feedback
             </button>
           </div>
         </nav>

--- a/frontend/src/pages/ListFeedback.tsx
+++ b/frontend/src/pages/ListFeedback.tsx
@@ -1,0 +1,161 @@
+import { useState, useEffect } from 'react';
+import { useAppContext } from '../context';
+import { Feedback, Team, TeamMember } from '../types';
+
+const ListFeedback = () => {
+  const { teams, members } = useAppContext();
+  const [feedbacks, setFeedbacks] = useState<Feedback[]>([]);
+  const [filteredFeedbacks, setFilteredFeedbacks] = useState<Feedback[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filterType, setFilterType] = useState<'all' | 'team' | 'member'>('all');
+  const [selectedTarget, setSelectedTarget] = useState<string>('');
+
+  useEffect(() => {
+    fetchFeedbacks();
+  }, []);
+
+  useEffect(() => {
+    filterFeedbacks();
+  }, [feedbacks, filterType, selectedTarget]);
+
+  const fetchFeedbacks = async () => {
+    try {
+      setLoading(true);
+      const response = await fetch('http://localhost:8080/api/v1/feedbacks');
+      if (!response.ok) {
+        throw new Error('Failed to fetch feedbacks');
+      }
+      const data = await response.json();
+      setFeedbacks(data || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const filterFeedbacks = () => {
+    let filtered = feedbacks;
+
+    if (filterType !== 'all') {
+      filtered = filtered.filter(feedback => feedback.targetType === filterType);
+    }
+
+    if (selectedTarget) {
+      filtered = filtered.filter(feedback => feedback.targetId === selectedTarget);
+    }
+
+    setFilteredFeedbacks(filtered);
+  };
+
+  const getTargetOptions = () => {
+    if (filterType === 'team') {
+      return teams;
+    } else if (filterType === 'member') {
+      return members;
+    }
+    return [];
+  };
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleString();
+  };
+
+  if (loading) {
+    return (
+      <div className="page">
+        <h2>Loading Feedbacks...</h2>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="page">
+        <h2>Error</h2>
+        <p className="error">{error}</p>
+        <button onClick={fetchFeedbacks} className="btn-primary">
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page">
+      <h2>Feedback List</h2>
+      
+      <div className="filters">
+        <div className="form-group">
+          <label htmlFor="filterType">Filter by Type:</label>
+          <select
+            id="filterType"
+            value={filterType}
+            onChange={(e) => {
+              setFilterType(e.target.value as 'all' | 'team' | 'member');
+              setSelectedTarget('');
+            }}
+            className="form-input"
+          >
+            <option value="all">All</option>
+            <option value="team">Teams</option>
+            <option value="member">Members</option>
+          </select>
+        </div>
+
+        {filterType !== 'all' && (
+          <div className="form-group">
+            <label htmlFor="selectedTarget">
+              Select {filterType === 'team' ? 'Team' : 'Member'}:
+            </label>
+            <select
+              id="selectedTarget"
+              value={selectedTarget}
+              onChange={(e) => setSelectedTarget(e.target.value)}
+              className="form-input"
+            >
+              <option value="">All {filterType}s</option>
+              {getTargetOptions().map((option: Team | TeamMember) => (
+                <option key={option.id} value={option.id}>
+                  {option.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+
+      <div className="feedback-stats">
+        <p>
+          Showing {filteredFeedbacks.length} of {feedbacks.length} feedbacks
+        </p>
+      </div>
+
+      <div className="feedback-list">
+        {filteredFeedbacks.length === 0 ? (
+          <p className="no-data">No feedbacks found.</p>
+        ) : (
+          filteredFeedbacks.map((feedback) => (
+            <div key={feedback.id} className="feedback-card">
+              <div className="feedback-header">
+                <span className={`feedback-type ${feedback.targetType}`}>
+                  {feedback.targetType.toUpperCase()}
+                </span>
+                <span className="feedback-target">{feedback.targetName}</span>
+                <span className="feedback-date">
+                  {formatDate(feedback.createdAt.toString())}
+                </span>
+              </div>
+              <div className="feedback-content">
+                {feedback.content}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ListFeedback;

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+echo "🛑 Stopping Coaching Application..."
+echo "=================================="
+
+echo "📋 Checking if Docker Compose services are running..."
+if docker-compose ps -q 2>/dev/null | grep -q .; then
+    echo "🔄 Stopping all Docker Compose services..."
+    docker-compose down --remove-orphans
+    
+    echo "🧹 Cleaning up containers and networks..."
+    docker-compose down -v
+    
+    echo "📊 Current Docker status:"
+    docker-compose ps
+else
+    echo "ℹ️  No Docker Compose services are currently running"
+fi
+
+echo "🔍 Checking for any remaining coaching-related containers..."
+remaining_containers=$(docker ps -a --filter name=coaching- -q)
+if [ ! -z "$remaining_containers" ]; then
+    echo "🧹 Removing remaining coaching containers..."
+    docker rm -f $remaining_containers
+fi
+
+echo "=================================="
+echo "✅ Coaching Application stopped!"
+echo "💡 To start again: ./start.sh"
+echo "=================================="


### PR DESCRIPTION
## Summary
- Created build-all.sh script to build both frontend and backend components
- Created stop.sh script to cleanly stop all Docker Compose services
- Implemented comprehensive feedback listing page with filtering capabilities by team or member
- Enhanced UI with proper styling for feedback cards and filters

## Features Added

### Build Scripts
- **build-all.sh**: Automated script that builds both backend (Go) and frontend (React/TypeScript) with proper error handling
- **stop.sh**: Clean shutdown script for Docker Compose services with container cleanup

### Feedback Listing Page
- **ListFeedback.tsx**: New page component that displays all feedback with filtering options
- Filter by type (All, Teams, Members)
- Filter by specific team or member
- Responsive design with feedback cards showing type, target, date, and content
- Real-time feedback statistics display

### UI/UX Improvements
- Added "List Feedback" navigation button
- Enhanced CSS styling for feedback display
- Color-coded feedback type badges (team vs member)
- Proper error handling and loading states

## Test Plan
- [x] Backend tests pass: `go test ./...`
- [x] Frontend builds successfully
- [x] Build scripts execute without errors
- [x] Stop script cleanly shuts down services
- [x] Feedback listing page renders correctly
- [x] Filtering functionality works as expected
- [x] Navigation between pages works seamlessly

## Prompt
Task 7: Make sure you have a build-all.sh script and stop.sh script. Make sure there is a page the list all feedback per team or per member. when you done open a PR using gh and use this prompt as part of the message.

## Test Output
```
Backend Tests:
ok  	coaching-backend	(cached)
?   	coaching-backend/database	[no test files]
?   	coaching-backend/handlers	[no test files]
ok  	coaching-backend/models	(cached)

Frontend Tests:
Some existing test failures unrelated to new changes (test suite needs improvement for better element selection)
```

🤖 Generated with [opencode](https://opencode.ai)