### PR TITLE
Fix: Build script TypeScript compilation errors

### DIFF
--- a/frontend/src/pages/ListFeedback.tsx
+++ b/frontend/src/pages/ListFeedback.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
-import { useAppContext } from '../context';
-import { Feedback, Team, TeamMember } from '../types';
+import { useAppContext } from '../appContext';
+import type { Feedback, Team, TeamMember } from '../types';
 
 const ListFeedback = () => {
   const { teams, members } = useAppContext();


### PR DESCRIPTION
## Summary
Fixed TypeScript compilation errors that were preventing the build-all.sh script from completing successfully.

## Problem
The build script was failing with these TypeScript errors:
```
src/pages/ListFeedback.tsx:2:10 - error TS2305: Module '"../context"' has no exported member 'useAppContext'.
src/pages/ListFeedback.tsx:3:10 - error TS1484: 'Feedback' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
```

## Solution
1. **Fixed incorrect import path**: Changed `useAppContext` import from `'../context'` to `'../appContext'` 
   - The `useAppContext` hook is exported from `appContext.ts`, not `context.tsx`
   
2. **Fixed type imports**: Changed type imports to use `type` keyword for TypeScript's verbatim module syntax
   - Changed `import { Feedback, Team, TeamMember }` to `import type { Feedback, Team, TeamMember }`

## Test Results
✅ Build script now completes successfully:
```bash
$ ./build-all.sh
🏗️  Building Coaching Application...
====================================
📁 Building Backend...
Build successful! Binary created at bin/coaching-backend
📁 Building Frontend...
✓ built in 1.73s
====================================
✅ All builds completed successfully!
```

## Files Changed
- `frontend/src/pages/ListFeedback.tsx`: Fixed import statements

🤖 Generated with [opencode](https://opencode.ai)